### PR TITLE
Support multithreaded migration

### DIFF
--- a/src/main/java/org/elasticsearch/river/solr/SolrRiver.java
+++ b/src/main/java/org/elasticsearch/river/solr/SolrRiver.java
@@ -291,9 +291,8 @@ public class SolrRiver extends AbstractRiverComponent implements River {
                 QueryResponse queryResponse = solrServer.query(solrQuery);
                 long numFound = queryResponse.getResults().getNumFound();
                 if (numFound < startParam) {
-                    if (logger.isWarnEnabled()) {
-                        logger.warn(getCurrentThreadPrefix() + " The solr query {} returned 0 documents", solrQuery);
-                    }
+                    logger.info(getCurrentThreadPrefix() + " Finishing work as no more results returned from solr - numFound: " + numFound + ", " +
+                            "start: " + startParam);
                     // no more docs to work with
                     return;
                 }


### PR DESCRIPTION
Currently, only one single thread is working on migration of data from solr to es. For huge data set, like millions of records in solr, this can consume a lot of time.

With this feature, users can specify an extra config `'num_workers'` to specify the number of parallel threads that will work on migration.
With multithreaded support, migration can happen a lot faster for huge data sets.

e.g.

```
curl -XPUT localhost:9200/_river/solr_river/_meta -d '
{
    "type" : "solr",
    "close_on_completion" : "true",
    "solr" : {
        "url" : "http://localhost:8383/solr/core-name",
        "q" : "*:*",
        "rows" : 5000
    },
    "index" : {
        "index" : "solr",
        "type" : "import",
        "bulk_size" : 5000,
        "max_concurrent_bulk" : 10,
        "num_workers" : 10
    }
}'
```
